### PR TITLE
Add support for first weekday + dataview notation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
 	"author": "Charles Feval",
 	"description": "Track your tasks across all the notes in your workspace. Organize your day. Plan your work",
 	"authorUrl": "https://fev.al",
-	"version": "1.0.6",
+	"version": "1.1.0",
 	"minAppVersion": "1.0.0",
 	"isDesktopOnly": false
 }

--- a/src/Views/ProletarianWizardSettingsTab.ts
+++ b/src/Views/ProletarianWizardSettingsTab.ts
@@ -100,7 +100,7 @@ export class ProletarianWizardSettingsTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Use Dataview Syntax")
-			.setDesc("on will use: [due:: 2025-01-01] of will use default: @due(2025-01-01)")
+			.setDesc("On will use: [due:: 2025-01-01], Off will use default: @due(2025-01-01)")
 			.addToggle((toggle) => toggle
 					.setValue(this.plugin.settings.useDataviewSyntax)
 					.onChange(async (value) => {

--- a/src/Views/ProletarianWizardSettingsTab.ts
+++ b/src/Views/ProletarianWizardSettingsTab.ts
@@ -74,10 +74,40 @@ export class ProletarianWizardSettingsTab extends PluginSettingTab {
 					})
 			);
 
-		let spanArchiveFromError = containerEl.createEl("span", {
+		const spanArchiveFromError = containerEl.createEl("span", {
 			text: "",
 			cls: "pw-error",
 		});
+
+		new Setting(containerEl)
+			.setName("First weekday")
+			.setDesc("Specify the first weekday weekend filtering")
+			.addDropdown((dropDown)=>{
+				[
+					"Monday",
+					"Tuesday",
+					"Wednesday",
+					"Thursday",
+					"Friday",
+					"Saturday",
+					"Sunday"
+				].forEach((display, index) => dropDown.addOption((index+1).toString(), display))
+				dropDown.onChange(async (value: string) =>	{
+					this.plugin.settings.firstWeekday = parseInt(value);
+					await this.plugin.saveSettings();
+				});
+			})
+
+		new Setting(containerEl)
+			.setName("Use Dataview Syntax")
+			.setDesc("on will use: [due:: 2025-01-01] of will use default: @due(2025-01-01)")
+			.addToggle((toggle) => toggle
+					.setValue(this.plugin.settings.useDataviewSyntax)
+					.onChange(async (value) => {
+						this.plugin.settings.useDataviewSyntax = value;
+						await this.plugin.saveSettings();
+					})
+			);
 
 		new Setting(containerEl)
 			.setName("Ignore archived todo")

--- a/src/domain/FileTodoParser.ts
+++ b/src/domain/FileTodoParser.ts
@@ -1,11 +1,12 @@
 import { IFile } from "./IFile";
 import { ITodoParsingResult, LineOperations } from "./LineOperations";
+import { ProletarianWizardSettings } from "./ProletarianWizardSettings";
 import { TodoItem } from "./TodoItem";
 
 export class FileTodoParser<TFile> {
 	private lineOperations: LineOperations;
-	constructor() {
-		this.lineOperations = new LineOperations();
+	constructor(settings: ProletarianWizardSettings) {
+		this.lineOperations = new LineOperations(settings);
 	}
 
 	private createTodoTreeStructure(

--- a/src/domain/LineOperations.ts
+++ b/src/domain/LineOperations.ts
@@ -57,20 +57,120 @@ export class LineOperations {
     )}${space(line.date, ": ")}${line.line}`;
   }
 
-  attributesToString(
-    attributesStructure: IAttributesStructure
-  ): string {
-    return (
-      attributesStructure.textWithoutAttributes +
-      " " +
-      Object.keys(attributesStructure.attributes)
-        .map((key) =>
-          typeof attributesStructure.attributes[key] === "boolean"
-            ? `@${key}`
-            : `@${key}(${attributesStructure.attributes[key]})`
-        )
-        .join(" ")
-    );
+  /**
+   * Provide a RegExp for matching attributes, depending on the syntax settings.
+   * For "classic" syntax, it’s something like `@due(2024-02-02)`,
+   * For "dataview" syntax, it’s something like `[due:: 2024-02-02]`.
+   */
+  private getAttributeRegex(): RegExp {
+    if (this.settings?.useDataviewSyntax) {
+      // Example pattern for [key:: value]
+      return /\[([^:\]]+)::([^\]]+)\]/g;
+    } else { // Classic pattern for @key(value)
+      return /@(\w+)(?:\(([^)]+)\))?/g;
+    }
+  }
+
+  /**
+   * Convert a matched string (like `@due(2025-01-01)` or `[due:: 2025-01-01]`)
+   * into an array: `[attributeKey, attributeValueOrBoolean]`.
+   */
+  private parseSingleAttribute(matchStr: string): [string, string | boolean] {
+    if (this.settings?.useDataviewSyntax) {
+      const regex = /\[([^:\]]+)::([^\]]+)\]/;
+      const submatch = regex.exec(matchStr);
+      if (!submatch) {
+        // fallback if something goes wrong
+        return ["", false];
+      }
+      const key = submatch[1].trim();
+      const value = submatch[2].trim();
+      return [key, value];
+    } else {
+      // For classic syntax: "@(\w+)(?:\(([^)]+)\))?"
+      const regex = /@(\w+)(?:\(([^)]+)\))?/;
+      const submatch = regex.exec(matchStr);
+      if (!submatch) {
+        return ["", false];
+      }
+      const key = submatch[1].trim();
+      const val = submatch[2] ? submatch[2].trim() : true;
+      return [key, val];
+    }
+  }
+
+  /**
+   * Convert a single `key` and `value` into a string
+   * according to the currently used syntax.
+   *
+   * e.g. with classic syntax:
+   *   if value is boolean => `@due`
+   *   if value is string  => `@due(2025-01-01)`
+   * e.g. with dataview syntax:
+   *   `[due:: 2025-01-01]`
+   */
+  private attributeToString(key: string, value: string | boolean): string {
+		if (this.settings?.useDataviewSyntax) {
+      // For Dataview: `[key:: value]`
+      // In case value is boolean (like a tag), just store the key or do some fallback
+      if (typeof value === "boolean") {
+        // Maybe store `[key:: true]` or skip it—decide how you want it.
+        return `[${key}:: true]`;
+      }
+      return `[${key}:: ${value}]`;
+    } else {
+      // For classic: `@key` or `@key(value)`
+      if (typeof value === "boolean") {
+        return `@${key}`;
+      }
+      return `@${key}(${value})`;
+    }
+  }
+
+  /**
+   * Parse the attributes from a given line, removing those attribute tokens
+   * from the text and returning a map of { key -> value } plus the stripped text.
+   */
+  parseAttributes(text: string): IAttributesStructure {
+    const regexp = this.getAttributeRegex();
+    const matches = text.match(regexp);
+
+    const res: IDictionary<string | boolean> = {};
+    if (!matches) return { textWithoutAttributes: text, attributes: res };
+
+    let textWithoutAttributes = text;
+
+    matches.forEach((match) => {
+      const [attrKey, attrValue] = this.parseSingleAttribute(match);
+      if (!attrKey) return; // skip if something invalid
+
+      res[attrKey] = attrValue;
+      // Remove that chunk from the text
+      textWithoutAttributes = textWithoutAttributes.replace(match, "");
+    });
+
+    return { textWithoutAttributes: textWithoutAttributes.trim(), attributes: res };
+  }
+
+  /**
+   * Build a single string from `textWithoutAttributes` + the attributes' dictionary.
+   * E.g. "Buy milk" + { due: "2025-01-01", critical: true }
+   * => "Buy milk @due(2025-01-01) @critical"
+   * or => "Buy milk [due:: 2025-01-01] [critical:: true]"
+   */
+  attributesToString(attributesStructure: IAttributesStructure): string {
+    const { textWithoutAttributes, attributes } = attributesStructure;
+    const attributeStr = Object.keys(attributes)
+      .map((key) => {
+        const val = attributes[key];
+        return this.attributeToString(key, val);
+      })
+      .join(" ");
+
+    // add a space only if there are attributes
+    return attributeStr
+      ? `${textWithoutAttributes} ${attributeStr}`.trim()
+      : textWithoutAttributes;
   }
 
   convertAttributes(line: string): string {
@@ -91,7 +191,7 @@ export class LineOperations {
         if (completion !== null) {
           attributes.attributes[key] = completion;
         }
-      } else if (attributes.attributes[key] === true){
+      } else if (val === true){
         // try to convert tags like @today into @due(the_date)
         const completion = Completion.completeDate(key);
         if (completion !== null) {
@@ -145,27 +245,6 @@ export class LineOperations {
                   ? TodoStatus.Delegated
                   : TodoStatus.Todo;
   };
-
-  parseAttributes(text: string): IAttributesStructure {
-    const regexp = / @(\w+)(?:\(([^)]+)\))?/g;
-    const matches = text.match(regexp);
-    const res: IDictionary<string | boolean> = {};
-    if (!matches) return { textWithoutAttributes: text, attributes: res };
-    let textWithoutAttributes = text;
-    matches.forEach((match) => {
-      const regexp = / @(\w+)(?:\(([^)]+)\))?/g;
-
-      const submatch = regexp.exec(" " + match + " ");
-      if (!submatch) {
-        throw Error("No match?");
-        return;
-      }
-      res[submatch[1]] = submatch[2] || true;
-      textWithoutAttributes = textWithoutAttributes.replace(match, "");
-    });
-
-    return { textWithoutAttributes, attributes: res };
-  }
 
   private getIndentationLevel(str: string) {
     return (str.match(/ /g)?.length || 0) + (str.match(/\t/g)?.length || 0) * 4;

--- a/src/domain/ProletarianWizardSettings.ts
+++ b/src/domain/ProletarianWizardSettings.ts
@@ -6,6 +6,8 @@ export interface ProletarianWizardSettings {
 	dueDateAttribute: string;
 	completedDateAttribute: string;
 	selectedAttribute: string;
+	useDataviewSyntax: boolean;
+	firstWeekday: number
 }
 
 export const DEFAULT_SETTINGS: ProletarianWizardSettings = {
@@ -16,4 +18,6 @@ export const DEFAULT_SETTINGS: ProletarianWizardSettings = {
 	dueDateAttribute: "due",
 	completedDateAttribute: "completed",
 	selectedAttribute: "selected",
+	useDataviewSyntax: false,
+	firstWeekday: 1
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ import { OpenReportCommand } from "./Commands/OpenReportCommand";
 export default class ProletarianWizard extends Plugin {
 	logger: ILogger = new ConsoleLogger(LogLevel.ERROR);
 	settings: ProletarianWizardSettings;
-	fileTodoParser: FileTodoParser<TFile> = new FileTodoParser();
+	fileTodoParser: FileTodoParser<TFile>;
 	folderTodoParser: FolderTodoParser<TFile>;
 	todoIndex: TodoIndex<TFile>;
 
@@ -36,6 +36,7 @@ export default class ProletarianWizard extends Plugin {
 	async onload() {
 		this.logger.info(`Loading PW`);
 		await this.loadSettings();
+		this.fileTodoParser = new FileTodoParser(this.settings);
 
 		this.folderTodoParser = new FolderTodoParser({
 			fileTodoParser: this.fileTodoParser,

--- a/src/ui/TodoItemComponent.tsx
+++ b/src/ui/TodoItemComponent.tsx
@@ -53,6 +53,7 @@ export interface TodoItemComponentProps {
 export function TodoItemComponent({todo, deps, playSound, dontCrossCompleted}: TodoItemComponentProps) {
   const app = deps.app;
   const settings = deps.settings;
+	const fileOperations = new FileOperations(settings);
 
   async function openFileAsync(file: TFile, line: number, inOtherLeaf: boolean) {
     let leaf = app.workspace.getLeaf();
@@ -86,7 +87,7 @@ export function TodoItemComponent({todo, deps, playSound, dontCrossCompleted}: T
       item.setTitle(`${otherIcon} Change priority to ${name}`)
       item.setIcon(icon)
       item.onClick((evt) => {
-        FileOperations.updateAttributeAsync(todo, "priority", name).then()
+				fileOperations.updateAttributeAsync(todo, "priority", name).then()
       })
     })
   }
@@ -105,14 +106,14 @@ export function TodoItemComponent({todo, deps, playSound, dontCrossCompleted}: T
     menu.addItem((item) => {
       item.setTitle("🔁 Reset priority")
       item.setIcon("reset")
-      item.onClick((evt) => FileOperations.removeAttributeAsync(todo, "priority").then())
+      item.onClick((evt) => fileOperations.removeAttributeAsync(todo, "priority").then())
     })
     menu.addSeparator()
     menu.addItem((item) => {
       item.setTitle("📌 Toggle selected")
       item.setIcon("pin")
       item.onClick((evt) => {
-        FileOperations.updateAttributeAsync(todo, settings.selectedAttribute, !todo.attributes[settings.selectedAttribute])
+				fileOperations.updateAttributeAsync(todo, settings.selectedAttribute, !todo.attributes[settings.selectedAttribute])
       })
     })
     menu.showAtMouseEvent(evt)

--- a/src/ui/TodoStatusComponent.tsx
+++ b/src/ui/TodoStatusComponent.tsx
@@ -41,11 +41,12 @@ export interface TodoSatusComponentProps {
 export function TodoStatusComponent({todo, deps, settings, playSound}: TodoSatusComponentProps) {
   
   const addChangeStatusMenuItem = (menu: Menu, status: TodoStatus, label: string) => {
-    menu.addItem((item) => {
+    const fileOperations: FileOperations = new FileOperations(settings)
+		menu.addItem((item) => {
       item.setTitle(label)
       item.onClick(() => {
         todo.status = status
-        FileOperations.updateTodoStatus(todo, settings.completedDateAttribute)
+				fileOperations.updateTodoStatus(todo, settings.completedDateAttribute)
       })
     })
   }
@@ -66,6 +67,7 @@ export function TodoStatusComponent({todo, deps, settings, playSound}: TodoSatus
   }
 
   const onclick = (evt: any) => {
+		const fileOperations: FileOperations = new FileOperations(settings)
     if (evt.defaultPrevented) {
       return
     }
@@ -76,7 +78,7 @@ export function TodoStatusComponent({todo, deps, settings, playSound}: TodoSatus
       playSound.fireAsync("checked").then()
     }
 		todo.status = wasCompleted ? TodoStatus.Todo : TodoStatus.Complete
-		FileOperations.updateTodoStatus(todo, settings.completedDateAttribute)
+		fileOperations.updateTodoStatus(todo, settings.completedDateAttribute)
   }
 
   return <div className="pw-todo-checkbox" onClick={onclick} onAuxClick={onauxclick}>


### PR DESCRIPTION
Awesome plugin! Thanks for creating it

This adds 2 new features:
1. Select first weekday. This will affect hidden weekend days. Without this option, the plugin is unusable in some countries.
2. Support dataview task notation like [due:: 2025-01-01]. This is huge for those of us already using this convention to organize tasks.